### PR TITLE
bug fix: corrected logic to return data for latest semester

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,7 +116,7 @@ Getting Subject detail
   # instantiate w = Webportal() and login before this
 
   semesters = w.get_registered_semesters()
-  sem = semesters[-1] # get latest sem
+  sem = semesters[0] # get latest sem
 
   reg = w.get_registered_subjects_and_faculties(sem)
   print(*reg.subjects, sep="\n")

--- a/pyjiit/attendance.py
+++ b/pyjiit/attendance.py
@@ -44,9 +44,9 @@ class AttendanceMeta:
         self.semesters = [Semester.from_json(i) for i in resp["semlist"]]
 
     def latest_header(self):
-        return self.headers[-1]
+        return self.headers[0]
 
     def latest_semester(self):
-        return self.semesters[-1]
+        return self.semesters[0]
 
 


### PR DESCRIPTION
Previously, the data returned was from the first semester. It now returns data for the latest semester.