### PR TITLE
fix: update login endpoint to 'generatewebtoken' and handle HTTP errors

### DIFF
--- a/pyjiit/wrapper.py
+++ b/pyjiit/wrapper.py
@@ -117,7 +117,7 @@ class Webportal:
         :raises LoginError: Raised for any error in the remote API while Logging in
         """
         pretoken_endpoint = "/token/pretoken-check"
-        token_endpoint = "/token/generate-token1"
+        token_endpoint = "/token/generatewebtoken"
 
 
         payload = {


### PR DESCRIPTION
` student_login()`  was crashing with the error  ` TypeError: 'int' object is not subscriptable. `

After some poking around in the inspect page of my browser I found that the correct endpoint would be `"/token/generatewebtoken"`.

They changed the old `generate-token1` endpoint and it's returning a 404. Which I confirmed, by printing `resp`.

```
{'timestamp': 1777964801458, 'status': 404, 'error': 'Not Found', 'message': 'No message available', 'path': '/StudentPortalAPI/token/generate-token1'}
```

**changing the endpoint token in `student_login()`  gives the usual `JAYPEE` output.**